### PR TITLE
feat: add link for @fastify/view support

### DIFF
--- a/docs/resources/integrations.md
+++ b/docs/resources/integrations.md
@@ -19,7 +19,7 @@ Use at your own risk! They may not support Eta v3 yet either.
 
 - Opine (see https://github.com/asos-craigmorten/opine/tree/main/examples/eta)
 - Alosaur (see https://github.com/alosaur/alosaur/tree/master/examples/eta)
-- Fastify (see https://github.com/fastify/point-of-view) - currently only works for eta v2. Plain to support v3
+- Fastify (see https://github.com/fastify/point-of-view) - currently only supports eta v2, but plans to support v3
 
 ## Tools for Eta development
 

--- a/docs/resources/integrations.md
+++ b/docs/resources/integrations.md
@@ -19,6 +19,7 @@ Use at your own risk! They may not support Eta v3 yet either.
 
 - Opine (see https://github.com/asos-craigmorten/opine/tree/main/examples/eta)
 - Alosaur (see https://github.com/alosaur/alosaur/tree/master/examples/eta)
+- Fastify (see https://github.com/fastify/point-of-view) - currently only works for eta v2. Plain to support v3
 
 ## Tools for Eta development
 

--- a/versioned_docs/version-2.x.x/resources/integrations.md
+++ b/versioned_docs/version-2.x.x/resources/integrations.md
@@ -20,3 +20,4 @@ Use at your own risk!
 - Opine (see https://github.com/asos-craigmorten/opine/tree/main/examples/eta)
 - Alosaur (see https://github.com/alosaur/alosaur/tree/master/examples/eta)
 - Rollup Plugin (see https://github.com/stateful/rollup-plugin-eta)
+- Fastify (see https://github.com/fastify/point-of-view) - currently only works for eta v2. Plain to support v3

--- a/versioned_docs/version-2.x.x/resources/integrations.md
+++ b/versioned_docs/version-2.x.x/resources/integrations.md
@@ -20,4 +20,4 @@ Use at your own risk!
 - Opine (see https://github.com/asos-craigmorten/opine/tree/main/examples/eta)
 - Alosaur (see https://github.com/alosaur/alosaur/tree/master/examples/eta)
 - Rollup Plugin (see https://github.com/stateful/rollup-plugin-eta)
-- Fastify (see https://github.com/fastify/point-of-view) - currently only works for eta v2. Plain to support v3
+- Fastify (see https://github.com/fastify/point-of-view) - currently only supports eta v2, but plans to support v3


### PR DESCRIPTION
Eta js 2 is already supported by fastify with @fastify/view.
Probably Eta 3 will be supported. Otherwhise I think is a good idea to add links.
When Eta will be supported, probably I will edit docs creating a section like "Express.js"