### PR TITLE
Fix layout doc link and add content

### DIFF
--- a/docs/intro/template-syntax.md
+++ b/docs/intro/template-syntax.md
@@ -57,6 +57,12 @@ A template file can only have one parent layout (though layouts themselves can h
 <% layout("./path-to-layout") %>
 ```
 
+To render child content in the layout, use `it.body`.
+
+```
+<%~ it.body %>
+```
+
 ### Name Resolution of Partials and Layouts
 
 If you're running Eta in Node.js or Deno, Eta will automatically try to resolve partials and layouts from inside the filesystem. Ex. `<%~ include("/header.eta") %>` will look for a file called `header.eta` in the `views` directory of your project.

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -161,7 +161,7 @@ function Home() {
                 </li>
                 <li>
                   Eta supports <b>layouts</b> out of the box (
-                  <a href="/docs/learn/layouts">learn more</a>)
+                  <a href="/docs/intro/template-syntax#partials-and-layouts">learn more</a>)
                 </li>
                 <li>
                   Eta allows <b>left whitespace control</b> (with <code>-</code>


### PR DESCRIPTION
Just had a bit of trouble finding layout documentations.

~~I also failed to find if there was a place to set a global template on engine registration? [Fastify](https://github.com/fastify/point-of-view#options) supports this setting. It seems to me setting this doesn't work right now.~~ It seems to work! I just forgot to reload my server.

Thanks!