### PR TITLE
docs: define ETA engine in Express walkaround

### DIFF
--- a/docs/resources/express.md
+++ b/docs/resources/express.md
@@ -7,28 +7,69 @@ Eta no longer supports the Express.js `app.engine()` function, but it's still co
 
 ```js
 const express = require("express")
+const path = require("node:path")
+const { Eta } = require("eta")
+
 const app = express()
-const path = require("path")
-const port = 3000
 
-var { Eta } = require("eta")
+const eta = new Eta({
+  // Views directory path
+  views: path.join(__dirname, "views"), // on Deno : `${Deno.cwd()}/views/`
 
-// views directory
-let viewpath = path.join(__dirname, "views")
-// on Deno, use let viewpath = Deno.cwd()+'/views/'
-let eta = new Eta({ views: viewpath, cache: true })
-
-/* no more needed with Deno or Node (Eta v3.x.x)
-app.engine("eta", eta.render)
-app.set("view engine", "eta")
-*/
+  // Any other option...
+  cache: true
+})
 
 app.get("/", (req, res) => {
-  // use status(statusNumber) and send(template)
-  res.status(200).send(eta.render("index", { title: "Hey", place: "Hello there!" }))
+  const renderedTemplate = eta.render("index", { title: "Hello", place: "there!" }) // create `index.eta` in the `views` folder
+  res.status(200).send(renderedTemplate)
 })
 
-app.listen(port, () => {
-  console.log(`Example app listening on port ${port}`)
+app.listen(3000, () => {
+  console.log("Server listening on port 3000")
 })
+```
+
+### Alternatively, define an Express app engine using ETA
+
+Missing the good'old `res.render` to render computed templates ? Here is a quick walk around to achieve the same behaviour throughout the whole application.
+
+Note : `app.engine("eta", eta.render)` is no longer supported on `v3.x.x` for Node.js and Deno
+
+
+```js
+const express = require("express")
+const path = require("node:path")
+const { Eta } = require("eta")
+
+// Create app
+const app = express()
+
+// Setup eta
+const eta = new Eta({ views: path.join(__dirname, "views") })
+app.engine("eta", buildEtaEngine())
+app.set("view engine", "eta")
+
+// Home route
+app.get("/", (req, res) => {
+  res.render("home", { message: "Hello world !" }) // create `home.eta` in the `views` folder
+});
+
+// Start server
+app.listen(3000, () => {
+  console.log("Server listening on port 3000")
+});
+
+
+function buildEtaEngine() {
+  return (path, opts, callback) => {
+    try {
+      const fileContent = eta.readFile(path);
+      const renderedTemplate = eta.renderString(fileContent, opts);
+      callback(null, renderedTemplate);
+    } catch (error) {
+      callback(error);
+    };
+  };
+}
 ```


### PR DESCRIPTION
As suggested [here](https://github.com/eta-dev/eta/issues/279#issuecomment-2008385500), this PR adds some documentation on how to import ETA as an Express view engine, so it's possible to use `res.render(TEMPLATE, DATA)` instead of `eta.render()` (thus importing the `eta` instance in each controller)